### PR TITLE
video bar for navigation in video label tool

### DIFF
--- a/static/annotate-generic-ui.js
+++ b/static/annotate-generic-ui.js
@@ -236,7 +236,7 @@ export default function(impl) {
 				});
 			},
 			getrelpos: function(e){
-				const tbar = document.getElementById('totalbar');
+				const tbar = this.$refs.totalBar;
 				var rect = tbar.getBoundingClientRect();
 				
 				var x = e.clientX - rect.left; //x position within the element.
@@ -252,7 +252,7 @@ export default function(impl) {
 				var relpos = this.videobarpos; //getrelpos(e);
 				var pos = (relpos*100) + '%';
 				// console.log(pos)
-				const pbar = this.$refs.position_bar;
+				const pbar = this.$refs.positionBar;
 				pbar.style.width = pos
 				const jumpTo = Math.floor(this.numFrames*relpos)
 				this.getFrame(jumpTo);
@@ -262,7 +262,7 @@ export default function(impl) {
 				var relpos= this.getrelpos(e);
 				this.videobarpos = relpos;
 
-				var ptip = this.$refs.position_tooltip;
+				var ptip = this.$refs.tooltipText;
 				var pos = (relpos*100) + '%';
 				const jumpTo = Math.floor(this.numFrames*relpos)
 				ptip.textContent = jumpTo;
@@ -355,13 +355,13 @@ export default function(impl) {
 			<div v-if="sourceType == 'video'" class="row align-items-center g-1">
 			<div class="videobar">
 			<div class="tooltip">
-				<div id="totalbar" 
+				<div class="totalbar" ref="totalBar"
 				v-on:mouseover="updatetooltip" 
 				v-on:click="tbarclick" 
 				v-on:mousemove="updatetooltip">
-					<div ref="position_bar"></div>
+					<div class="positionbar" ref="positionBar"></div>
 				</div>
-				<span class="tooltiptext" ref="position_tooltip"></span>
+				<span class="tooltiptext" ref="tooltipText"></span>
 			</div>
 			</div>
 			</div>

--- a/static/annotate-generic-ui.js
+++ b/static/annotate-generic-ui.js
@@ -34,6 +34,9 @@ export default function(impl) {
 
 				// error message to display e.g. if we ran out of images to label
 				message: null,
+
+				// videobar state 
+				videobarpos: 0., 
 			};
 			if(impl.data) {
 				let impl_data = impl.data.call(this);
@@ -232,6 +235,40 @@ export default function(impl) {
 					}
 				});
 			},
+			getrelpos: function(e){
+				const tbar = document.getElementById('totalbar');
+				var rect = tbar.getBoundingClientRect();
+				
+				var x = e.clientX - rect.left; //x position within the element.
+				var width = rect.right - rect.left;
+				var relpos = x/width;
+				// console.log(rect)
+				// console.log(rect.width)
+				// console.log(relpos);
+				return relpos;
+			},
+			tbarclick: function(e){
+
+				var relpos = this.videobarpos; //getrelpos(e);
+				var pos = (relpos*100) + '%';
+				// console.log(pos)
+				const pbar = this.$refs.position_bar;
+				pbar.style.width = pos
+				const jumpTo = Math.floor(this.numFrames*relpos)
+				this.getFrame(jumpTo);
+				// console.log(pbar.style.width)
+			  },
+			updatetooltip: function(e){
+				var relpos= this.getrelpos(e);
+				this.videobarpos = relpos;
+
+				var ptip = this.$refs.position_tooltip;
+				var pos = (relpos*100) + '%';
+				const jumpTo = Math.floor(this.numFrames*relpos)
+				ptip.textContent = jumpTo;
+				ptip.style.left = pos;
+			  }
+
 		},
 	};
 	let template = `
@@ -316,11 +353,28 @@ export default function(impl) {
 			[IM_BELOW]
 
 			<div v-if="sourceType == 'video'" class="row align-items-center g-1">
+			<div class="videobar">
+			<div class="tooltip">
+				<div id="totalbar" 
+				v-on:mouseover="updatetooltip" 
+				v-on:click="tbarclick" 
+				v-on:mousemove="updatetooltip">
+					<div ref="position_bar"></div>
+				</div>
+				<span class="tooltiptext" ref="position_tooltip"></span>
+			</div>
+			</div>
+			</div>
+			<div v-if="sourceType == 'video'" class="row align-items-center g-1">
 				<div class="col-auto">
 					<button v-on:click="getFrame(frameIdx-1)" type="button" class="btn btn-primary">Prev Frame</button>
 				</div>
 				<div class="col-auto">
+
+			  </div>
+				<div class="col-auto">
 					<template v-if="response != null">
+						<input v-model="frameIdx" placeholder="enter frame...">
 						Frame {{ frameIdx }} / {{ numFrames }}
 					</template>
 				</div>
@@ -328,6 +382,7 @@ export default function(impl) {
 					<button v-on:click="getFrame(frameIdx+1)" type="button" class="btn btn-primary">Next Frame</button>
 				</div>
 			</div>
+			
 		</template>
 	</div>`;
 	for(var key in impl.methods) {

--- a/static/annotate-generic-ui.js
+++ b/static/annotate-generic-ui.js
@@ -353,25 +353,23 @@ export default function(impl) {
 			[IM_BELOW]
 
 			<div v-if="sourceType == 'video'" class="row align-items-center g-1">
-			<div class="videobar">
-			<div class="tooltip">
-				<div class="totalbar" ref="totalBar"
-				v-on:mouseover="updatetooltip" 
-				v-on:click="tbarclick" 
-				v-on:mousemove="updatetooltip">
-					<div class="positionbar" ref="positionBar"></div>
+				<div class="videobar">
+					<div class="tooltip">
+						<div class="totalbar" ref="totalBar"
+							v-on:mouseover="updatetooltip"
+							v-on:click="tbarclick"
+							v-on:mousemove="updatetooltip">
+							<div class="positionbar" ref="positionBar"></div>
+						</div>
+						<span class="tooltiptext" ref="tooltipText"></span>
+					</div>
 				</div>
-				<span class="tooltiptext" ref="tooltipText"></span>
 			</div>
-			</div>
-			</div>
+
 			<div v-if="sourceType == 'video'" class="row align-items-center g-1">
 				<div class="col-auto">
 					<button v-on:click="getFrame(frameIdx-1)" type="button" class="btn btn-primary">Prev Frame</button>
 				</div>
-				<div class="col-auto">
-
-			  </div>
 				<div class="col-auto">
 					<template v-if="response != null">
 						<input v-model="frameIdx" placeholder="enter frame...">

--- a/static/style.css
+++ b/static/style.css
@@ -167,14 +167,14 @@ See: https://github.com/vuejs/vue/issues/11321
     text-align: left;
 }
 
-.videobar #totalbar {
+.videobar .totalbar {
 	width: 100%;
 	height: 20px;
-	max-width: 500px;
+	/* max-width: 500px; */
 	  background: #ddd;
   }
   
-  .videobar #positionbar {
+  .videobar .positionbar {
 	width: 0%;
 	height: 20px;
 	  line-height: 20px;
@@ -184,7 +184,7 @@ See: https://github.com/vuejs/vue/issues/11321
   
   .videobar .tooltip {
 	width: 100%;
-	max-width: 400px; /* TODO would like bar to be as wide as the video frame above allows */
+	/* max-width: 400px; TODO would like bar to be as wide as the video frame above allows */
 	height: 20px;
 	max-height: 20px;
 	background: #555;

--- a/static/style.css
+++ b/static/style.css
@@ -166,3 +166,64 @@ See: https://github.com/vuejs/vue/issues/11321
 .tooltip-inner {
     text-align: left;
 }
+
+.videobar #totalbar {
+	width: 100%;
+	height: 20px;
+	max-width: 500px;
+	  background: #ddd;
+  }
+  
+  .videobar #positionbar {
+	width: 0%;
+	height: 20px;
+	  line-height: 20px;
+	  background: #0088FF;
+	color: #fff;
+  }
+  
+  .videobar .tooltip {
+	width: 100%;
+	max-width: 400px; /* TODO would like bar to be as wide as the video frame above allows */
+	height: 20px;
+	max-height: 20px;
+	background: #555;
+	opacity: .5;
+	position: relative;
+	display: inline-block;
+  }
+  
+  
+  .videobar .tooltip .tooltiptext {
+	visibility: hidden;
+	width: 120px;
+	background-color: #555;
+	color: #fff;
+	text-align: center;
+	border-radius: 5px;
+	padding: 6px 0;
+	position: absolute;
+	z-index: 1;
+	top: 110%;
+	left: 0%;/* will update this on mouse move */
+	margin-left: -60px;
+	opacity: 0;
+	transition: opacity 0.3s;
+  }
+  
+  .videobar .tooltip .tooltiptext::after {
+	content: "";
+	position: absolute;
+	bottom: 100%;  /* At the top of the tooltip */
+	left: 50%;
+	margin-left: -5px;
+	border-width: 2px;
+	/* top: 100%; At the bottom of the tooltip */
+	border-style: solid;
+	border-color: transparent transparent #555 transparent;
+  }
+  
+  .videobar .tooltip:hover .tooltiptext {
+	visibility: visible;
+	opacity: 1;
+  }

--- a/static/style.css
+++ b/static/style.css
@@ -167,14 +167,14 @@ See: https://github.com/vuejs/vue/issues/11321
     text-align: left;
 }
 
-.videobar .totalbar {
+.video-bar .total-bar {
 	width: 100%;
 	height: 20px;
 	/* max-width: 500px; */
 	  background: #ddd;
   }
   
-  .videobar .positionbar {
+  .video-bar .position-bar {
 	width: 0%;
 	height: 20px;
 	  line-height: 20px;
@@ -182,7 +182,7 @@ See: https://github.com/vuejs/vue/issues/11321
 	color: #fff;
   }
   
-  .videobar .tooltip {
+  .video-bar .tooltip {
 	width: 100%;
 	/* max-width: 400px; TODO would like bar to be as wide as the video frame above allows */
 	height: 20px;
@@ -194,7 +194,7 @@ See: https://github.com/vuejs/vue/issues/11321
   }
   
   
-  .videobar .tooltip .tooltiptext {
+  .video-bar .tooltip .tooltip-text {
 	visibility: hidden;
 	width: 120px;
 	background-color: #555;
@@ -211,7 +211,7 @@ See: https://github.com/vuejs/vue/issues/11321
 	transition: opacity 0.3s;
   }
   
-  .videobar .tooltip .tooltiptext::after {
+  .video-bar .tooltip .tooltip-text::after {
 	content: "";
 	position: absolute;
 	bottom: 100%;  /* At the top of the tooltip */
@@ -223,7 +223,7 @@ See: https://github.com/vuejs/vue/issues/11321
 	border-color: transparent transparent #555 transparent;
   }
   
-  .videobar .tooltip:hover .tooltiptext {
+  .video-bar .tooltip:hover .tooltip-text {
 	visibility: visible;
 	opacity: 1;
   }


### PR DESCRIPTION
The overall goal is adding ways to navigate your videos and your labels beyond what next and prev give you.
There are two modalities in this commit:

1. a bar that lets you both visualize where you are in the video and jump to a location (as well as tell you where you would jump to).
2. a text input to directly jump to a specified location.

I noticed right now the bar will update its visual state on click, and also change frameIdx,  but other ways to update frameIdx won't update the bar state (eg typing it on the text input).  

I can fix this on a later commit,  and use this commit to get a basic navigation thing in there (it is still functional). It depends on what level of polish you prefer on commits.

About code, 
converted getElementById to use $refs.

Should work as in the gif. 
![bar_at_work](https://user-images.githubusercontent.com/565364/115492619-1aff4900-a230-11eb-924c-3779c50c1091.gif)

Also, et me know if there's some convention I'm breaking that you are trying to stick to.